### PR TITLE
Ci check url

### DIFF
--- a/ci_pipeline/check_url.py
+++ b/ci_pipeline/check_url.py
@@ -1,0 +1,78 @@
+import re
+from pathlib import Path, PurePath
+from typing import Any, Dict, List, Tuple, Union
+
+import requests
+
+PathLike = Union[Path, PurePath, str]
+
+SOURCE = PurePath(".") / "source"
+
+FAIL_REGEXES = {
+    r"http://": "Only use https in URLs",
+    r"http[s]+://": "Format all external links like `Optional link text <https://www.url.com>`_",
+}
+CHECK_RESPONSE_REGEX = re.compile(r"`(?:[^<> ]*? )*?<(.*?)>`_")
+
+
+def interface() -> None:
+    assert Path(SOURCE).is_dir()
+    paths = Path(SOURCE).glob("**/*.rst")
+    issues = {}
+    for path in paths:
+        issues[path] = check_file(path)
+
+    for path, path_issues in issues.items():
+        for issue in path_issues:
+            print_issue(path=path, issue=issue)
+
+
+def check_file(path: PathLike) -> List[Dict[str, Any]]:
+    contents = load_contents(path=path)
+    urls, linenos = find_urls(contents)
+    issues = []
+    for url, lineno in zip(urls, linenos):
+        issue = {"lineno": lineno, "url": url}
+        try:
+            status = get_status(url=url)
+            if status == 200:
+                continue
+            status = str(status)
+        except requests.exceptions.MissingSchema as e:
+            status = str(e)
+        issue["status"] = status
+        issues.append(issue)
+    return issues
+
+
+def print_issue(path: PathLike, issue: Dict[str, Any]) -> None:
+    url = issue["url"]
+    lineno = issue["lineno"]
+    status = issue["status"]
+    print(f"{path}:{lineno} URL<{url}> STATUS[{status}]")
+
+
+def load_contents(path: PathLike) -> List[str]:
+    with open(path, "r") as f:
+        contents = f.readlines()
+    return contents
+
+
+def find_urls(contents: List[str]) -> Tuple[List[str], List[int]]:
+    urls = []
+    linenos = []
+    for lineno, line in enumerate(contents):
+        line_urls = re.findall(CHECK_RESPONSE_REGEX, line)
+        for url in line_urls:
+            urls.append(url)
+            linenos.append(lineno)
+    return (urls, linenos)
+
+
+def get_status(url: str) -> int:
+    response = requests.get(url=url)
+    return response.status_code
+
+
+if __name__ == "__main__":
+    interface()

--- a/env.yml
+++ b/env.yml
@@ -8,6 +8,7 @@ dependencies:
   - rstcheck=3.3.1
   - black=19.10
   - pip=21.2.4
+  - requests=2.26.0
   - pip:
       - snooty-lextudio=1.11.4.dev0
       - sphinx-rtd-theme=1.0.0


### PR DESCRIPTION
Added utility to check URLs with an eye toward making it part of continuous integration. Prints to console, only if there is an issue with a URL.

Format:

```
path/to/file.rst:lineno URL<url> STATUS[status]
```

Future todo:
1. Talk with Louis about continuous integration
2. Output to log or other file descriptor as necessary instead of just a bare print() call.