### PR TITLE
Added support email to page footer

### DIFF
--- a/source/_templates/footer.html
+++ b/source/_templates/footer.html
@@ -1,0 +1,14 @@
+{% extends "!footer.html" %} {% block extrafooter %}
+<!-- Email help footer -->
+</p>
+<div class="support">
+  Still stuck after reading?
+  <a href="mailto:support@listserv.uab.edu">Email us!</a>
+</div>
+<style>
+  .support {
+    color: #404040; /* ReadTheDocs Off Black */
+    font-weight: bolder;
+  }
+</style>
+{% endblock %} {{ super() }}

--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -1,5 +1,5 @@
 {% extends "!layout.html" %} {% block footer %} {{ super() }}
-
+<!-- Style -->
 <style>
   /*
   Colors from: https://www.uab.edu/toolkit/brand-basics/colors
@@ -21,7 +21,7 @@
     font-weight: bolder;
   }
   .wy-menu-vertical a {
-    color: #fcfcfc; /* ReadTheDocs Off Black */
+    color: #fcfcfc; /* ReadTheDocs Off White */
     font-weight: 500;
   }
   .wy-menu-vertical a:hover {


### PR DESCRIPTION
Added our support email and a catchy tagline, in bold, to the footer of every page on readthedocs.