### PR TITLE
Redirect To GitHub docs

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -1,8 +1,12 @@
 .. Main UAB RC documentation for anything relating to Cheaha and the new UAB
    Cloud system.
-
+ 
 UAB Research Computing Documentation
 ====================================
+
+.. important:
+
+   The main documentation for UAB Research computing has been moved to `uabrc.github.io <uabrc.github.io>`__. Please visit there for up-to-date documentation
 
 .. add short blurb about research computing here
 
@@ -14,21 +18,3 @@ resources are freely available to use by any researcher or instructor at UAB.
 
 .. MKD: currently thinking we place and edit all TOC in index, but hide them from rendering on the actual page. They'll appear on the sidebar. Then we keep things on the mainpage to a minimum, like the CGDS docs, Only including quickstart information. Modelled after https://sphinx-rtd-theme.readthedocs.io/en/stable/index.html
 
-.. Hidden ToC
-
-.. toctree::
-   :maxdepth: 2
-   :hidden:
-
-   welcome/welcome.rst
-   account_management/index.rst
-   data_management/index.rst
-   cheaha/index.rst
-   uab_cloud/index.rst
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`

--- a/source/index.rst
+++ b/source/index.rst
@@ -1,20 +1,10 @@
 .. Main UAB RC documentation for anything relating to Cheaha and the new UAB
    Cloud system.
  
-UAB Research Computing Documentation
-====================================
+Go To uabrc.github.io
+=====================
 
 .. important::
 
    The main documentation for UAB Research computing has been moved to `uabrc.github.io <uabrc.github.io>`__. Please visit there for up-to-date documentation
-
-.. add short blurb about research computing here
-
-UAB Research Computing (RC) is a group of IT and data scientists dedicated
-technical support for researchers at UAB, specifically related to cloud and
-cluster computing. The main resources run by UAB RC are the `Cheaha cluster
-computing platform <rc.uab.edu>`__ and UAB Cloud (coming soon!). Both of these
-resources are freely available to use by any researcher or instructor at UAB.
-
-.. MKD: currently thinking we place and edit all TOC in index, but hide them from rendering on the actual page. They'll appear on the sidebar. Then we keep things on the mainpage to a minimum, like the CGDS docs, Only including quickstart information. Modelled after https://sphinx-rtd-theme.readthedocs.io/en/stable/index.html
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -4,7 +4,7 @@
 UAB Research Computing Documentation
 ====================================
 
-.. important:
+.. important::
 
    The main documentation for UAB Research computing has been moved to `uabrc.github.io <uabrc.github.io>`__. Please visit there for up-to-date documentation
 


### PR DESCRIPTION
Changed front page to have direct links to the new docs and removed the entire table of contents. Was not able to add in the automatic redirect quickly